### PR TITLE
Improve weather tool response to reference city

### DIFF
--- a/src/app/api/chat/tools/getWeather.ts
+++ b/src/app/api/chat/tools/getWeather.ts
@@ -1,19 +1,17 @@
-
 import { tool } from "ai";
 import { z } from "zod";
 
 export const getWeather = tool({
-  description:
-    "show the weather in a given city to the user",
+  description: "show the weather in a given city to the user",
   parameters: z.object({
     city: z.string().describe("The city to get weather for"),
   }),
   execute: async ({ city }: { city: string }) => {
-    const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+    const weatherOptions = ["sunny", "cloudy", "rainy", "snowy", "windy"];
     // fake wait for weather data
     await new Promise((resolve) => setTimeout(resolve, 3000));
-    return weatherOptions[
-      Math.floor(Math.random() * weatherOptions.length)
-    ];
+    const weather =
+      weatherOptions[Math.floor(Math.random() * weatherOptions.length)];
+    return `The weather in ${city} is currently ${weather}.`;
   },
 });


### PR DESCRIPTION
## Summary
- personalize getWeather tool to include the requested city in its response

## Testing
- `npx eslint src/app/api/chat/tools/getWeather.ts && echo 'Lint OK'`
- `npm run lint` *(fails: 'GitHubButton' is defined but never used... and more)*

------
https://chatgpt.com/codex/tasks/task_b_68a61cd61f408322b2bc5257079f4352